### PR TITLE
Replaced mysql-python package with mysqlclient package

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-MySQL-python > 0.0.0
+mysqlclient
 nose
 coverage


### PR DESCRIPTION
fixes https://github.com/shippableSamples/sample_python_mysql/issues/7
 The latter supports python 3.x as well with the exception of 3.2 while the former doesnot support python 3.x.
https://pypi.python.org/pypi/MySQL-python/1.2.5
https://pypi.python.org/pypi/mysqlclient